### PR TITLE
Api doc rename

### DIFF
--- a/docs/api_docs.rst
+++ b/docs/api_docs.rst
@@ -1,6 +1,6 @@
-===========
-API V2 Docs
-===========
+========
+API Docs
+========
 
 This is the API documentation for Packaginator. It is designed to be language and tool agnostic.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Contents:
    testing_instructions
    management_commands
    pypi_issues
-   api_v2_docs
+   api_docs
    contributors
    repo_handlers
    vcs_protocols_research


### PR DESCRIPTION
```
renamed API docs

The docs were seemingly mistitled for V2, until there is in fact a V2, it
would seem simpler just to have things named api docs. When a V2 is available
the api docs can have a section for v1 and v2.
```
