### PR TITLE
Small settings improvement

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -278,3 +278,5 @@ try:
     from local_settings import *
 except ImportError:
     pass
+if LOCAL_INSTALLED_APPS:
+    INSTALLED_APPS.extend(LOCAL_INSTALLED_APPS)


### PR DESCRIPTION
```
allow local settings to add to installed apps

if local settings define a LOCAL_INSTALLED_APPS var, then these apps will
be added to installed apps. Useful for having debugging or testing related
apps not defined in main settings file
```
