### PR TITLE
99% test coverage on grid views

### DIFF
--- a/apps/grid/tests/test_views.py
+++ b/apps/grid/tests/test_views.py
@@ -165,13 +165,18 @@ class FunctionalGridTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'grid/add_grid_package.html')
 
-        # Test form post
-        #count = GridPackage.objects.count()
-        #response = self.client.post(url, {
-            #'package': 'TEST NAME',
-        #}, follow=True)
-        #self.assertEqual(GridPackage.objects.count(), count + 1)
-        #self.assertContains(response, 'TEST TITLE')
+        # Test form post for existing package
+        response = self.client.post(url, {
+            'package': 2,
+        }, follow=True)
+        self.assertContains(response, 
+                            '&#39;Supertester&#39; is already in this grid.')
+        # Test form post for new package
+        response = self.client.post(url, {
+            'package': 2,
+        }, follow=True)
+        self.assertContains(response, 
+                            '&#39;Supertester&#39; is already in this grid.')
 
 
     def test_add_new_grid_package_view(self):
@@ -201,7 +206,7 @@ class FunctionalGridTest(TestCase):
 
 
     def test_ajax_grid_list_view(self):
-        url = reverse('ajax_grid_list') + '?q=Testing&package_id=2' 
+        url = reverse('ajax_grid_list') + '?q=Testing&package_id=4' 
         response = self.client.get(url)
         self.assertContains(response, 'Testing')
 

--- a/apps/grid/views.py
+++ b/apps/grid/views.py
@@ -204,6 +204,7 @@ def add_grid_package(request, grid_slug, template_name="grid/add_grid_package.ht
 
 @login_required
 def add_new_grid_package(request, grid_slug, template_name="package/package_form.html"):
+    """Add a package to a grid that isn't yet represented on the site."""
     
     grid = get_object_or_404(Grid, slug=grid_slug)
     

--- a/apps/grid/views.py
+++ b/apps/grid/views.py
@@ -169,6 +169,7 @@ def edit_element(request, feature_id, package_id, template_name="grid/edit_eleme
 
 @login_required
 def add_grid_package(request, grid_slug, template_name="grid/add_grid_package.html"):
+    """Add an existing package to this grid."""
 
     grid = get_object_or_404(Grid, slug=grid_slug)
     grid_package = GridPackage()

--- a/apps/grid/views.py
+++ b/apps/grid/views.py
@@ -182,11 +182,11 @@ def add_grid_package(request, grid_slug, template_name="grid/add_grid_package.ht
             GridPackage.objects.get(grid=grid, package=package)
             message = "Sorry, but '%s' is already in this grid." % package.title
         except GridPackage.DoesNotExist:
-            package = GridPackage(
+            grid_package = GridPackage(
                         grid=grid, 
                         package=package
                     )
-            package.save()
+            grid_package.save()
             redirect = request.POST.get('redirect','')
             if redirect:
                 return HttpResponseRedirect(redirect)

--- a/fixtures/test_initial_data.json
+++ b/fixtures/test_initial_data.json
@@ -33,12 +33,28 @@
     "pk" : 3
   },
   { "fields" : { "created" : "2010-01-01 12:00:00",
+        "grid" : 1,
+        "modified" : "2010-01-01 12:00:00",
+        "package" : 3
+      },
+    "model" : "grid.gridpackage",
+    "pk" : 3
+  },
+  { "fields" : { "created" : "2010-01-01 12:00:00",
         "grid" : 2,
         "modified" : "2010-01-01 12:00:00",
         "package" : 3
       },
     "model" : "grid.gridpackage",
     "pk" : 4
+  },
+  { "fields" : { "created" : "2010-01-01 12:00:00",
+        "grid" : 1,
+        "modified" : "2010-01-01 12:00:00",
+        "package" : 2
+      },
+    "model" : "grid.gridpackage",
+    "pk" : 5
   },
   { "fields" : { "created" : "2010-01-01 12:00:00",
         "description" : "Does this package come with tests?",
@@ -129,6 +145,24 @@
       },
     "model" : "package.package",
     "pk" : 3
+  },
+  { "fields" : { "category" : 1,
+        "created" : "2010-01-01 15:00:00",
+        "modified" : "2010-01-02 20:00:00",
+        "participants" : "pydanny",
+        "pypi_downloads" : 0,
+        "pypi_url" : "",
+        "related_packages" : [  ],
+        "repo_commits" : 0,
+        "repo_description" : "Yet another test package, with no grid affiliation.",
+        "repo_forks" : 0,
+        "repo_url" : "",
+        "repo_watchers" : 0,
+        "slug" : "another-test",
+        "title" : "Another Test"
+      },
+    "model" : "package.package",
+    "pk" : 4
   },
   { "fields" : { "name" : "Moderators",
         "permissions" : [ [ "delete_gridpackage",


### PR DESCRIPTION
Only thing not covered is an optional redirect in add_grid_package (apps/grid/views.py, lines 190-192). I wonder if that can be cut out of the view... I can't find it being used anywhere in the code, and I'm not sure what the purpose is.
