### PR TITLE
add stricter constraint when retrieving permissions in test

### DIFF
--- a/apps/grid/tests/test_views.py
+++ b/apps/grid/tests/test_views.py
@@ -304,7 +304,8 @@ class GridPermissionTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_add_grid_permission_success(self):
-        add_grid_perm = Permission.objects.get(codename='add_grid')
+        add_grid_perm = Permission.objects.get(codename='add_grid',
+            content_type__app_label='grid')
         self.user.user_permissions.add(add_grid_perm)
         response = self.client.get(self.test_add_url)
         self.assertEqual(response.status_code, 200)
@@ -314,7 +315,8 @@ class GridPermissionTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_edit_grid_permission_success(self):
-        edit_grid_perm = Permission.objects.get(codename='change_grid')
+        edit_grid_perm = Permission.objects.get(codename='change_grid',
+                content_type__app_label='grid')
         self.user.user_permissions.add(edit_grid_perm)
         response = self.client.get(self.test_edit_url)
         self.assertEqual(response.status_code, 200)
@@ -342,7 +344,8 @@ class GridPackagePermissionTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_add_grid_package_permission_success(self):
-        add_grid_perm = Permission.objects.get(codename='add_gridpackage')
+        add_grid_perm = Permission.objects.get(codename='add_gridpackage',
+                content_type__app_label='grid')
         self.user.user_permissions.add(add_grid_perm)
         response = self.client.get(self.test_add_url)
         self.assertEqual(response.status_code, 200)
@@ -352,7 +355,8 @@ class GridPackagePermissionTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_add_new_grid_package_permission_success(self):
-        add_new_grid_perm = Permission.objects.get(codename='add_gridpackage')
+        add_new_grid_perm = Permission.objects.get(codename='add_gridpackage',
+                content_type__app_label='grid')
         self.user.user_permissions.add(add_new_grid_perm)
         response = self.client.get(self.test_add_new_url)
         self.assertEqual(response.status_code, 200)
@@ -362,8 +366,8 @@ class GridPackagePermissionTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
     def test_delete_grid_package_permission_success(self):
-        delete_grid_perm = Permission.objects.get(codename=
-                                                  'delete_gridpackage')
+        delete_grid_perm = Permission.objects.get(codename='delete_gridpackage',
+                content_type__app_label='grid')
         self.user.user_permissions.add(delete_grid_perm)
         response = self.client.get(self.test_delete_url)
         self.assertEqual(response.status_code, 302)
@@ -385,7 +389,8 @@ class GridFeaturePermissionTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_add_feature_permission_success(self):
-        add_feature = Permission.objects.get(codename='add_feature')
+        add_feature = Permission.objects.get(codename='add_feature',
+                content_type__app_label='grid')
         self.user.user_permissions.add(add_feature)
         response = self.client.get(self.test_add_url)
         self.assertEqual(response.status_code, 200)
@@ -395,7 +400,8 @@ class GridFeaturePermissionTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_edit_feature_permission_success(self):
-        edit_feature = Permission.objects.get(codename='change_feature')
+        edit_feature = Permission.objects.get(codename='change_feature',
+                content_type__app_label='grid')
         self.user.user_permissions.add(edit_feature)
         response = self.client.get(self.test_edit_url)
         self.assertEqual(response.status_code, 200)
@@ -405,7 +411,8 @@ class GridFeaturePermissionTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
     def test_delete_feature_permission_success(self):
-        delete_feature = Permission.objects.get(codename='delete_feature')
+        delete_feature = Permission.objects.get(codename='delete_feature',
+                content_type__app_label='grid')
         self.user.user_permissions.add(delete_feature)
         response = self.client.get(self.test_delete_url)
         self.assertEqual(response.status_code, 302)
@@ -426,7 +433,8 @@ class GridElementPermissionTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_edit_element_permission_success(self):
-        edit_element = Permission.objects.get(codename='change_element')
+        edit_element = Permission.objects.get(codename='change_element',
+                content_type__app_label='grid')
         self.user.user_permissions.add(edit_element)
         response = self.client.get(self.test_edit_url)
         self.assertEqual(response.status_code, 200)

--- a/apps/package/tests/test_views.py
+++ b/apps/package/tests/test_views.py
@@ -197,7 +197,8 @@ class PackagePermissionTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_add_package_permission_success(self):
-        add_package_perm = Permission.objects.get(codename="add_package")
+        add_package_perm = Permission.objects.get(codename="add_package",
+                content_type__app_label='package')
         self.user.user_permissions.add(add_package_perm)
         response = self.client.get(self.test_add_url)
         self.assertEqual(response.status_code, 200)
@@ -207,7 +208,8 @@ class PackagePermissionTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_edit_package_permission_success(self):
-        edit_package_perm = Permission.objects.get(codename="change_package")
+        edit_package_perm = Permission.objects.get(codename="change_package",
+                content_type__app_label='package')
         self.user.user_permissions.add(edit_package_perm)
         response = self.client.get(self.test_edit_url)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
this is both more robust, and also required in the case where any other apps
define a model with the name "package" such as djangopypi
