### PR TITLE
Fix for Issue 2: Adding 'usage_count' to the API

### DIFF
--- a/apps/apiv1/resources.py
+++ b/apps/apiv1/resources.py
@@ -90,6 +90,7 @@ class GridResource(EnhancedModelResource):
             url(
                 r"^%s/(?P<grid_name>[-\w]+)/packages/$" % GridResource._meta.resource_name,
                 self.get_packages,
+                name='api_grid_packages',
             ),
         ] 
 
@@ -163,6 +164,7 @@ class PackageResource(PackageResourceBase):
     last_modified_by  = fields.ForeignKey(UserResource, "created_by", null=True)
     pypi_version = fields.CharField('pypi_version')
     commits_over_52 = fields.CharField('commits_over_52')
+    usage_count = fields.CharField('get_usage_count')
 
     class Meta:
         queryset = Package.objects.all()

--- a/apps/apiv1/tests/test_grid.py
+++ b/apps/apiv1/tests/test_grid.py
@@ -1,0 +1,53 @@
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from grid.models import Grid, GridPackage
+from package.models import Package, Category
+import json
+
+
+class GridV1Tests(TestCase):
+    def setUp(self):
+        """
+        Set up initial data, done through Python because fixtures break way too
+        quickly with migrations and are terribly hard to maintain.
+        """
+        app = Category.objects.create(
+            title='App',
+            slug='app',
+        )
+        self.grid = Grid.objects.create(
+            title='A Grid',
+            slug='grid',
+        )
+        self.pkg1 = Package.objects.create(
+            title='Package1',
+            slug='package1',
+            category=app,
+        )
+        self.pkg2 = Package.objects.create(
+            title='Package2',
+            slug='package2',
+            category=app,
+        )
+        GridPackage.objects.create(package=self.pkg1, grid=self.grid)
+        GridPackage.objects.create(package=self.pkg2, grid=self.grid)
+        user = User.objects.create_user('user', 'user@packaginator.com', 'user')
+        self.pkg1.usage.add(user)
+        
+        
+    def test_01_grid_packages_usage(self):
+        urlkwargs = {'api_name': 'v1', 'grid_name': self.grid.slug}
+        url = reverse('api_grid_packages', kwargs=urlkwargs)
+        response = self.client.get(url)
+        # check that the request was successful
+        self.assertEqual(response.status_code, 200)
+        raw_json = response.content
+        package_list = json.loads(raw_json)
+        # turn the flat package list into a dictionary with the package slug as
+        # key for easier assertion of data integrity
+        package_dict = dict([(pkg['slug'], pkg) for pkg in package_list])
+        pkg1_usage_count = int(package_dict[self.pkg1.slug]['usage_count'])
+        pkg2_usage_count = int(package_dict[self.pkg2.slug]['usage_count'])
+        self.assertEqual(pkg1_usage_count, self.pkg1.usage.count())
+        self.assertEqual(pkg2_usage_count, self.pkg2.usage.count())

--- a/apps/apiv1/tests/test_package.py
+++ b/apps/apiv1/tests/test_package.py
@@ -1,0 +1,68 @@
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from grid.models import Grid, GridPackage
+from package.models import Package, Category
+import json
+
+
+class PackageV1Tests(TestCase):
+    def setUp(self):
+        """
+        Set up initial data, done through Python because fixtures break way too
+        quickly with migrations and are terribly hard to maintain.
+        """
+        app = Category.objects.create(
+            title='App',
+            slug='app',
+        )
+        self.grid = Grid.objects.create(
+            title='A Grid',
+            slug='grid',
+        )
+        self.pkg1 = Package.objects.create(
+            title='Package1',
+            slug='package1',
+            category=app,
+        )
+        self.pkg2 = Package.objects.create(
+            title='Package2',
+            slug='package2',
+            category=app,
+        )
+        GridPackage.objects.create(package=self.pkg1, grid=self.grid)
+        GridPackage.objects.create(package=self.pkg2, grid=self.grid)
+        user = User.objects.create_user('user', 'user@packaginator.com', 'user')
+        self.pkg1.usage.add(user)
+        
+        
+    def test_01_packages_usage(self):
+        urlkwargs_pkg1 = {
+            'api_name': 'v1',
+            'resource_name': 'package',
+            'pk': self.pkg1.slug,
+        }
+        url_pkg1 = reverse('api_dispatch_detail', kwargs=urlkwargs_pkg1)
+        response_pkg1 = self.client.get(url_pkg1)
+        # check that the request was successful
+        self.assertEqual(response_pkg1.status_code, 200)
+        # check that we have a usage_count equal to the one in the DB
+        raw_json_pkg1 = response_pkg1.content
+        pkg_1 = json.loads(raw_json_pkg1)
+        usage_count_pkg1 = int(pkg_1['usage_count'])
+        self.assertEqual(usage_count_pkg1, self.pkg1.usage.count())
+        # do the same with pkg2
+        urlkwargs_pkg2 = {
+            'api_name': 'v1',
+            'resource_name': 'package',
+            'pk': self.pkg2.slug,
+        }
+        url_pkg2 = reverse('api_dispatch_detail', kwargs=urlkwargs_pkg2)
+        response_pkg2 = self.client.get(url_pkg2)
+        # check that the request was successful
+        self.assertEqual(response_pkg2.status_code, 200)
+        # check that we have a usage_count equal to the one in the DB
+        raw_json_pkg2 = response_pkg2.content
+        pkg_2 = json.loads(raw_json_pkg2)
+        usage_count_pkg2 = int(pkg_2['usage_count'])
+        self.assertEqual(usage_count_pkg2, self.pkg2.usage.count())

--- a/apps/package/models.py
+++ b/apps/package/models.py
@@ -123,6 +123,9 @@ class Package(BaseModel):
         
         return self.participants.split(',')
     
+    def get_usage_count(self):
+        return self.usage.count()
+    
     def commits_over_52(self):
         now = datetime.now()
         commits = Commit.objects.filter(


### PR DESCRIPTION
Added a 'usage_count' field onto both the Package and Grid Packages APIs, using the newly created `get_usage_count` method on `package.models.Package` (for ease of use in the API, it's just a proxy to `self.usage.count`).

Added two tests for this both on grid and package level.
