### PR TITLE
Sentry error logging

### DIFF
--- a/requirements/packaginator.txt
+++ b/requirements/packaginator.txt
@@ -26,3 +26,9 @@ celery==2.2.4
 kombu==1.0.4
 django-celery==2.2.4
 django-kombu==0.9.2
+
+# Sentry
+django-sentry==1.6.9.1
+django-paging==0.2.2
+django-indexer==0.2.1
+uuid==1.30

--- a/settings.py
+++ b/settings.py
@@ -193,6 +193,9 @@ PREREQ_APPS = [
 
     # Celery task queue:
     'djcelery',
+    
+    # Sentry error logging:
+    'sentry.client',
 ]
 
 INSTALLED_APPS = PREREQ_APPS + PROJECT_APPS


### PR DESCRIPTION
Fixes issue 37 if the production server is configured correctly.

This means:

`SENTRY_KEY` has to match the sentry key of the packaginator-sentry deployement
`SENTRY_REMOTE_URL` has to be a list containing the packaginator-sentry deployement URL (eg: `['http://sentry.packaginator.com/store/']`
`SENTRY_NAME` should be the name of the packaginator deployement (eg: 'djangopackages')
