### PR TITLE
Fix "Category" column when rendered to grid_detail2

### DIFF
--- a/apps/grid/views.py
+++ b/apps/grid/views.py
@@ -60,7 +60,7 @@ def grid_detail(request, slug, template_name="grid/grid_detail.html"):
     element_map = build_element_map(elements)
 
     default_attributes = [('repo_description', 'Description'), 
-                ('Category',), ('pypi_downloads', 'Downloads'), ('last_updated', 'Last Updated'), ('pypi_version', 'Version'),
+                ('category','Category'), ('pypi_downloads', 'Downloads'), ('last_updated', 'Last Updated'), ('pypi_version', 'Version'),
                 ('repo', 'Repo'), ('commits_over_52', 'Commits'), ('repo_watchers', 'Repo watchers'), ('repo_forks', 'Forks'),
                 ('participant_list', 'Participants')
             ]


### PR DESCRIPTION
Found this while investigating issue 136. Danny and I talked about test coverage for this. The grid app needs tests that verify the rendered content of the page, which probably deserves its own issue.
