### PR TITLE
Fix 'Find another grid to join' button

### DIFF
--- a/templates/grid/ajax_grid_list.html
+++ b/templates/grid/ajax_grid_list.html
@@ -23,7 +23,7 @@
                 $('#grid-{{ grid.id }}').removeClass("clickable");
             });
             $('#grid-{{ grid.id }}').click(function() {
-                $('form:first').attr('action', "{% url add_grid_package grid.slug %}");                
+                $('form#find-a-grid-form').attr('action', "{% url add_grid_package grid.slug %}");
                 $("form#find-a-grid-form").submit();
             });
         {% endfor %}


### PR DESCRIPTION
The search form is the first form, so use the id selector instead

This is issue 118 in the main packaginator line.
