### PR TITLE
use Django template engine for more flexibility when rendering attributes

### DIFF
--- a/apps/grid/templatetags/grid_tags.py
+++ b/apps/grid/templatetags/grid_tags.py
@@ -75,10 +75,11 @@ def style_attribute(attribute_name, package):
             'commits_over_52': style_commits,
     }
 
-    value = getattr(package, attribute_name, '')
-
-    if hasattr(value, '__call__'):
-        value = value()
+    as_var = template.Variable('package.' + attribute_name)
+    try:
+        value = as_var.resolve({'package': package})
+    except template.VariableDoesNotExist:
+        value = ''
 
     if attribute_name in mappings.keys():
         return  mappings[attribute_name](value)


### PR DESCRIPTION
use Django template engine for more flexibility when rendering attributes

the prior method did a simple getattr on the package, but this doesn't allow
for any more powerful resolution of nested attributes. This would not allow
us to use more powerful linked data.

So for the pypi refactor, you could access the latest version with a template
variable like:

package.pypi.latest.version  >> 2.0.0

however passing an attribute like 'pypi.latest.version' fails massively with
the prior approach of a simple getattr. However Django has all the code needed
to resolve this into a proper value.

As a postscript, I'd rather see all this in python code, as some sort of utility
in the view code or something, but this change allows the pypi stuff to keep
moving forward.
